### PR TITLE
Fixing dependencies issue

### DIFF
--- a/aranet/aranet.py
+++ b/aranet/aranet.py
@@ -3,7 +3,7 @@ import optparse
 import os, json
 import numpy as np
 import pandas as pd
-from keras.preprocessing.sequence import pad_sequences
+from keras_preprocessing.sequence import pad_sequences
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ setup(name='aranet',
       license='GNU',
       packages=['aranet'],
       install_requires=[
-          'tensorflow-gpu',
+          'tensorflow',
           'torch',
           'sklearn',
-          'transformers==2.3.0', 'keras', 'pandas', 'numpy'
+          'transformers==2.3.0', 'keras', 'pandas', 'numpy', 'Keras-Preprocessing'
       ],
 
       entry_points={


### PR DESCRIPTION
### Description

This PR updates setup.py dependencies to resolve deprecation issues:

- Changed tensorflow-gpu to tensorflow

- Updated sklearn to scikit-learn

- Added keras-preprocessing

The addition of `keras-preprocessing` is part of fixing the issue of cannot import name 'pad_sequences' from 'keras.preprocessing.sequence' in aranet.py.

I verified installation with the updated dependencies and am currently using AraNet successfully as part of my future research. Thank you for your time.